### PR TITLE
Update UserDefaults.plist

### DIFF
--- a/SUS Inspector/UserDefaults.plist
+++ b/SUS Inspector/UserDefaults.plist
@@ -38,6 +38,14 @@
 	<array>
 		<dict>
 			<key>catalogOSVersion</key>
+			<string>10.16</string>
+			<key>catalogURL</key>
+			<string>https://swscan.apple.com/content/catalogs/others/index-10-16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog</string>
+			<key>catalogDisplayName</key>
+			<string>Big Sur</string>
+		</dict>		
+		<dict>
+			<key>catalogOSVersion</key>
 			<string>10.15</string>
 			<key>catalogURL</key>
 			<string>https://swscan.apple.com/content/catalogs/others/index-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog</string>


### PR DESCRIPTION
Add BigSur SUS catalog.  Even though some updates are now coming to Big Sur thru the MSU (Mobile Software Update) mechanism, there are still some products that appear in the SUS catalog for 10.16 like BridgeOS updates.